### PR TITLE
Add slides for the security headers presentation

### DIFF
--- a/2020/19.md
+++ b/2020/19.md
@@ -11,6 +11,8 @@ _team, management_
 
 _http, security_
 
+[Slides](https://static.ovalerio.net/presentations/http-security-headers/)
+
 ### Sponsors
 🏢 [Cowork Funchal](http://www.coworkfunchal.pt/)
 🍕 [Cloudflare](https://www.cloudflare.com/)


### PR DESCRIPTION
Noticed the slides were missing. Given they are available online, it doesn't hurt to add the link here.